### PR TITLE
include <memory>

### DIFF
--- a/src/mdns.cpp
+++ b/src/mdns.cpp
@@ -1,6 +1,7 @@
 #include "mdns_cpp/mdns.hpp"
 
 #include <iostream>
+#include <memory>
 #include <thread>
 
 #include "mdns.h"


### PR DESCRIPTION
fixes trivial compile issue on recent gcc