### PR TITLE
Allow control over running it in a separate thread

### DIFF
--- a/include/mdns_cpp/mdns.hpp
+++ b/include/mdns_cpp/mdns.hpp
@@ -14,7 +14,7 @@ class mDNS {
  public:
   ~mDNS();
 
-  void startService();
+  void startService(bool start_thread=true);
   void stopService();
   bool isServiceRunning();
 

--- a/src/mdns.cpp
+++ b/src/mdns.cpp
@@ -377,13 +377,17 @@ int service_callback(int sock, const struct sockaddr *from, size_t addrlen, mdns
 
 mDNS::~mDNS() { stopService(); }
 
-void mDNS::startService() {
+void mDNS::startService(bool start_thread) {
   if (running_) {
     stopService();
   }
 
   running_ = true;
-  worker_thread_ = std::thread([this]() { this->runMainLoop(); });
+  if(start_thread){
+    worker_thread_ = std::thread([this]() { this->runMainLoop(); });
+  } else {
+    this->runMainLoop();
+  }
 }
 
 void mDNS::stopService() {


### PR DESCRIPTION
First off, thanks for this brilliant library!

A user recently introduced this library into my open source project [wolf](https://github.com/games-on-whales/wolf) and everything seems to be working, expect for when it doesn't 😅 

A user reported the following exception:
```
mDNS: Local IPv4 address: 192.168.178.25
mDNS: Local IPv6 address: fd30:854e:2d95:0:e9d:92ff:fe84:f3a9
mDNS: Error: Failed to open any client sockets
```
I'm not sure what's causing it (any help in debugging that?) but when you `throw` from your thread I have no way to `catch` those exceptions from the main thread.  
So I've added a simple `bool` flag to avoid starting that thread automatically and instead do something like:

```c++
  std::thread([]() {
    logs::log(logs::info, "Starting mDNS service");
    try {
      // ...
      mdns.startService(false);
    } catch (const std::exception &e) {
      logs::log(logs::error, "mDNS error: {}", e.what());
    }
  }).detach();
``` 

To avoid crashing the main application when that fails. 

Let me know what you think!